### PR TITLE
Add compatibility with git worktrees

### DIFF
--- a/DataCollector/VersionInformationDataCollector.php
+++ b/DataCollector/VersionInformationDataCollector.php
@@ -46,7 +46,7 @@ class VersionInformationDataCollector extends DataCollector
         if (file_exists($rootDir . '/.svn/')) {
             $this->data->mode = self::SVN;
             $this->collectSvn($rootDir, $request, $response, $exception);
-        } elseif (file_exists($rootDir . '/.git/')) {
+        } elseif (file_exists($rootDir . '/.git')) {
             $this->data->mode = self::GIT;
             $this->collectGit($rootDir, $request, $response, $exception);
         } else {


### PR DESCRIPTION
Worktrees are different from the "normal" repo clones in that they contain the
file ".git" instead of directory. This trivial fix ensures that both directory
and file are accepted as git repo indicator.